### PR TITLE
init.edo.pwr.rc: Make double arguments into a string

### DIFF
--- a/rootdir/vendor/etc/init/init.edo.pwr.rc
+++ b/rootdir/vendor/etc/init/init.edo.pwr.rc
@@ -51,8 +51,8 @@ on charger
 
 on property:sys.boot_completed=1
     # Setting b.L scheduler parameters
-    write /proc/sys/kernel/sched_upmigrate 95 95
-    write /proc/sys/kernel/sched_downmigrate 85 85
+    write /proc/sys/kernel/sched_upmigrate "95 95"
+    write /proc/sys/kernel/sched_downmigrate "85 85"
     write /proc/sys/kernel/sched_group_upmigrate 100
     write /proc/sys/kernel/sched_group_downmigrate 85
     write /proc/sys/kernel/sched_walt_rotate_big_tasks 1


### PR DESCRIPTION
Write command in android accepts only 2 arguments. That is:
1. File that it will be actually written to.
2. Value to write to this file

If we pass the write command a third argument it will very much complain while building.
If we check the sysfs in kernel for those 2 files they do indeed want 2 arguments to the file.
So make the 2 arguments a string and kernel will handle the splitting.