### PR TITLE
Add dynamic partitions + seine fstab changes

### DIFF
--- a/rootdir/vendor/etc/fstab.edo
+++ b/rootdir/vendor/etc/fstab.edo
@@ -24,6 +24,6 @@ vendor                                     /vendor                 ext4    ro,ba
 /dev/block/zram0                           none                    swap    defaults                                                              zramsize=1073741824,max_comp_streams=8
 
 # External Devices
-/devices/platform/soc/8804000.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                                        voldmanaged=sdcard1:auto,encryptable=userdata
-/devices/platform/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    defaults                                            voldmanaged=usb:auto
+/devices/platform/soc/8804000.sdhci/mmc_host/mmc*     auto         auto    nosuid,nodev                                                          voldmanaged=sdcard1:auto,encryptable=userdata
+/devices/platform/soc/*.ssusb/*.dwc3/xhci-hcd.*.auto*   auto       auto    defaults                                                              voldmanaged=usb:auto
 

--- a/rootdir/vendor/etc/fstab.edo
+++ b/rootdir/vendor/etc/fstab.edo
@@ -2,7 +2,12 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-/dev/block/bootdevice/by-name/system       /            ext4    ro,barrier=1                                                  wait,slotselect,first_stage_mount
+# Logical Partitions
+system                                     /system                 ext4    ro,barrier=1,discard                                                  wait,slotselect,avb=vbmeta_system,logical,first_stage_mount,avb_keys=/avb/r-gsi.avbpubkey:/avb/s-gsi.avbpubkey
+product                                    /product                ext4    ro,barrier=1,discard                                                  wait,slotselect,avb=vbmeta_system,logical,first_stage_mount
+vendor                                     /vendor                 ext4    ro,barrier=1,discard                                                  wait,slotselect,avb,logical,first_stage_mount
+
+# Other Partitions
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,slotselect,first_stage_mount
 /dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults

--- a/rootdir/vendor/etc/fstab.edo
+++ b/rootdir/vendor/etc/fstab.edo
@@ -7,6 +7,9 @@ system                                     /system                 ext4    ro,ba
 product                                    /product                ext4    ro,barrier=1,discard                                                  wait,slotselect,avb=vbmeta_system,logical,first_stage_mount
 vendor                                     /vendor                 ext4    ro,barrier=1,discard                                                  wait,slotselect,avb,logical,first_stage_mount
 
+# Real first stage mount partitions
+/dev/block/by-name/metadata                /metadata               ext4    noatime,nosuid,nodev,discard                         wait,formattable,first_stage_mount
+
 # Other Partitions
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,slotselect,first_stage_mount
 /dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M

--- a/rootdir/vendor/etc/fstab.edo
+++ b/rootdir/vendor/etc/fstab.edo
@@ -12,7 +12,7 @@ vendor                                     /vendor                 ext4    ro,ba
 /dev/block/bootdevice/by-name/oem_a        /odm                    ext4    ro,barrier=1                                                          wait,first_stage_mount
 
 # Other Partitions
-/dev/block/bootdevice/by-name/userdata     /data                   ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata     /data                   ext4    noatime,nosuid,nodev,barrier=1,noauto_da_alloc,discard,errors=panic   latemount,wait,check,formattable,fileencryption=ice,keydirectory=/metadata/vold/metadata_encryption,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/frp          /persistent             emmc    defaults                                                              defaults
 /dev/block/bootdevice/by-name/dsp          /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic        wait,notrim,slotselect
 /dev/block/bootdevice/by-name/misc         /misc                   emmc    defaults                                                              defaults

--- a/rootdir/vendor/etc/fstab.edo
+++ b/rootdir/vendor/etc/fstab.edo
@@ -8,18 +8,22 @@ product                                    /product                ext4    ro,ba
 vendor                                     /vendor                 ext4    ro,barrier=1,discard                                                  wait,slotselect,avb,logical,first_stage_mount
 
 # Real first stage mount partitions
-/dev/block/by-name/metadata                /metadata               ext4    noatime,nosuid,nodev,discard                         wait,formattable,first_stage_mount
-/dev/block/bootdevice/by-name/oem_a        /odm         ext4    ro,barrier=1                                                  wait,first_stage_mount
+/dev/block/by-name/metadata                /metadata               ext4    noatime,nosuid,nodev,discard                                          wait,formattable,first_stage_mount
+/dev/block/bootdevice/by-name/oem_a        /odm                    ext4    ro,barrier=1                                                          wait,first_stage_mount
 
 # Other Partitions
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
-/dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
-/dev/block/bootdevice/by-name/dsp          /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim,slotselect
-/dev/block/bootdevice/by-name/misc         /misc        emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/userdata     /data                   ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
+/dev/block/bootdevice/by-name/frp          /persistent             emmc    defaults                                                              defaults
+/dev/block/bootdevice/by-name/dsp          /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic        wait,notrim,slotselect
+/dev/block/bootdevice/by-name/misc         /misc                   emmc    defaults                                                              defaults
 /dev/block/bootdevice/by-name/modem        /vendor/firmware_mnt    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait,slotselect
 /dev/block/bootdevice/by-name/bluetooth    /vendor/bt_firmware     vfat    ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait,slotselect
 /dev/block/bootdevice/by-name/persist      /mnt/vendor/persist     ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
 
-/devices/platform/soc/8804000.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                     voldmanaged=sdcard1:auto,encryptable=userdata
-/devices/platform/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    defaults                         voldmanaged=usb:auto
-/dev/block/zram0                            none        swap    defaults                                                      zramsize=1073741824,max_comp_streams=8
+#ZRAM/SWAP
+/dev/block/zram0                           none                    swap    defaults                                                              zramsize=1073741824,max_comp_streams=8
+
+# External Devices
+/devices/platform/soc/8804000.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                                        voldmanaged=sdcard1:auto,encryptable=userdata
+/devices/platform/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    defaults                                            voldmanaged=usb:auto
+

--- a/rootdir/vendor/etc/fstab.edo
+++ b/rootdir/vendor/etc/fstab.edo
@@ -9,9 +9,9 @@ vendor                                     /vendor                 ext4    ro,ba
 
 # Real first stage mount partitions
 /dev/block/by-name/metadata                /metadata               ext4    noatime,nosuid,nodev,discard                         wait,formattable,first_stage_mount
+/dev/block/bootdevice/by-name/oem_a        /odm         ext4    ro,barrier=1                                                  wait,first_stage_mount
 
 # Other Partitions
-/dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,slotselect,first_stage_mount
 /dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/dsp          /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim,slotselect


### PR DESCRIPTION
This fstab file was based on Kumano which is not
DP platform and thus they were missing.
While at it i included changes from seine fstab.
Such as:
	Add metadata partition
	Enforce oem_a
	Fix USB external storage path
	Fix userdata mount flags