### PR TITLE
[main] edo: fstab: Enable inlinecrypt flag for data

### DIFF
--- a/rootdir/vendor/etc/fstab.edo
+++ b/rootdir/vendor/etc/fstab.edo
@@ -12,7 +12,7 @@ vendor                                     /vendor                 ext4    ro,ba
 /dev/block/bootdevice/by-name/oem_a        /odm                    ext4    ro,barrier=1                                                          wait,first_stage_mount
 
 # Other Partitions
-/dev/block/bootdevice/by-name/userdata     /data                   ext4    noatime,nosuid,nodev,barrier=1,noauto_da_alloc,discard,errors=panic   latemount,wait,check,formattable,fileencryption=ice,keydirectory=/metadata/vold/metadata_encryption,quota,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata     /data                   ext4    noatime,nosuid,nodev,barrier=1,noauto_da_alloc,discard,errors=panic,inlinecrypt   latemount,wait,check,formattable,fileencryption=ice,keydirectory=/metadata/vold/metadata_encryption,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/frp          /persistent             emmc    defaults                                                              defaults
 /dev/block/bootdevice/by-name/dsp          /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic        wait,notrim,slotselect
 /dev/block/bootdevice/by-name/misc         /misc                   emmc    defaults                                                              defaults


### PR DESCRIPTION
On google msm-kernel-4.19 stable branch, these configs is enabled and used by Android 11.
```
CONFIG_FS_ENCRYPTION_INLINE_CRYPT=y
CONFIG_FS_VERITY=y
CONFIG_FS_VERITY_BUILTIN_SIGNATURES=y
```
Since we already upgraded to stock 11, new bootloader require this feature.
We need this flag to decrypt data partition on CAF LA.UM.9.12 kernel with latest bootloader, or decryption will be failed.