### PR TITLE
Add missing partitions to fstab

### DIFF
--- a/rootdir/vendor/etc/fstab.edo
+++ b/rootdir/vendor/etc/fstab.edo
@@ -17,6 +17,7 @@ odm                                        /odm                    ext4    ro,ba
 /dev/block/bootdevice/by-name/frp          /persistent             emmc    defaults                                                              defaults
 /dev/block/bootdevice/by-name/dsp          /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic        wait,notrim,slotselect
 /dev/block/bootdevice/by-name/misc         /misc                   emmc    defaults                                                              defaults
+/dev/block/bootdevice/by-name/spunvm       /mnt/vendor/spunvm      vfat    rw,noatime,shortname=lower,uid=1000,gid=1000,dmask=007,fmask=007,context=u:object_r:spunvm_file:s0  wait
 /dev/block/bootdevice/by-name/modem        /vendor/firmware_mnt    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait,slotselect
 /dev/block/bootdevice/by-name/bluetooth    /vendor/bt_firmware     vfat    ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait,slotselect
 /dev/block/bootdevice/by-name/persist      /mnt/vendor/persist     ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim

--- a/rootdir/vendor/etc/fstab.edo
+++ b/rootdir/vendor/etc/fstab.edo
@@ -6,6 +6,7 @@
 system                                     /system                 ext4    ro,barrier=1,discard                                                  wait,slotselect,avb=vbmeta_system,logical,first_stage_mount,avb_keys=/avb/r-gsi.avbpubkey:/avb/s-gsi.avbpubkey
 product                                    /product                ext4    ro,barrier=1,discard                                                  wait,slotselect,avb=vbmeta_system,logical,first_stage_mount
 vendor                                     /vendor                 ext4    ro,barrier=1,discard                                                  wait,slotselect,avb,logical,first_stage_mount
+odm                                        /odm                    ext4    ro,barrier=1,discard                                                  wait,slotselect,avb,logical,first_stage_mount
 
 # Real first stage mount partitions
 /dev/block/by-name/metadata                /metadata               ext4    noatime,nosuid,nodev,discard                                          wait,formattable,first_stage_mount


### PR DESCRIPTION
On edo devices the ODM partition is stored on super partition so lets add it as one.

Add spunvm partition.

I could not find a lot about this partition but it seems to be sm8250+ partition as any
sm8250 device has to have this partition in fstab.
So lets add it as well :)