### PR TITLE
[EDO] rootdir: Android.mk: Add entry for fstab on ramdisk root

### DIFF
--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -10,6 +10,15 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE := ramdisk-fstab.$(TARGET_DEVICE)
+LOCAL_SRC_FILES := vendor/etc/fstab.edo
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_STEM := fstab.$(TARGET_DEVICE)
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_RAMDISK_OUT)
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE := init.edo
 LOCAL_SRC_FILES := vendor/etc/init/init.edo.rc
 LOCAL_MODULE_TAGS := optional


### PR DESCRIPTION
Devices with Android Dynamic Partitions need a fstab on the
ramdisk root because they don't support system-as-root and
because it is not possible to specify the dynamic partitions
to mount early in the kernel device-tree.

For this reason, it is critical to have a fstab file in the
ramdisk, since it's the only place where we can read it as
per the specifications of the Android Open Source Project (AOSP):
add an entry to the makefile so that we can select this "module"
from our device-specific makefiles.