### PR TITLE
[EDO] platform: Inherit gsi_keys for GSI AVB public keys

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -380,3 +380,4 @@ PRODUCT_PROPERTY_OVERRIDES += \
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/gsi_keys.mk)


### PR DESCRIPTION
We want to support the GSI keys: inherit them to get them in.