### PR TITLE
[EDO] platform: Stop generating kernel panic on SDX55 failure

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -377,6 +377,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.surface_flinger.use_color_management=true \
     ro.surface_flinger.wcg_composition_dataspace=143261696
 
+# External modem
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.vendor.mdm_helper.fail_action=cold_reset
+
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)


### PR DESCRIPTION
It makes no sense to generate a kernel panic when the SDX55
modem fails to initialize. Just makes things harder to debug for
no reason.

Let's reset the modem and retry when this happens.