### PR TITLE
[EDO] platform: Declare TARGET_USES_ESOC

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -36,6 +36,9 @@ TARGET_HARDWARE_GRAPHICS_V3 := true
 # Keymaster 4
 TARGET_KEYMASTER_V4 := true
 
+# SDX55M PCI-e Modem
+TARGET_USES_ESOC := true
+
 # RIL
 TARGET_PER_MGR_ENABLED := true
 


### PR DESCRIPTION
This variable is used by device-sony-common to enable rfs
symlinks for the external modem.