### PR TITLE
[EDO] platform: Add libcirrusspkrprot and CS35L41 related properties

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -231,7 +231,8 @@ PRODUCT_PACKAGES += \
 # Audio
 PRODUCT_PACKAGES += \
     sound_trigger.primary.sm8250 \
-    audio.primary.sm8250
+    audio.primary.sm8250 \
+    libcirrusspkrprot
 
 # GFX
 PRODUCT_PACKAGES += \
@@ -356,6 +357,11 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Audio - QCOM proprietary
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.audio.adm.buffering.ms=3
+
+# Audio - Sony specific
+PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.audio.feature.dynamic_ecns.enable=true \
+    vendor.audio.enable.cirrus.speaker=true
 
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
We have to compile the libcirrusspkrprot for Sony and to enable
dynamic ECNS and the cirrus path via properties in order to get
speaker output with the CS35L41 amplifiers, found in the entire
EDO project.