### PR TITLE
[EDO] platform: Set ADM buffering to 2ms

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -356,7 +356,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Audio - QCOM proprietary
 PRODUCT_PROPERTY_OVERRIDES += \
-    vendor.audio.adm.buffering.ms=3
+    vendor.audio.adm.buffering.ms=2
 
 # Audio - Sony specific
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
On SM8250 the ADM buffering is reduced to 2 milliseconds.