### PR TITLE
[EDO] ueventd: Set system user/group on spss_utils

### DIFF
--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -69,6 +69,7 @@ firmware_directories /vendor/firmware_mnt/image/
 /dev/seemplog             0660   system     system
 /dev/pft                  0660   system     drmrpc
 /dev/spcom                0660   system     system
+/dev/spss_utils           0660   system     system
 /dev/sp_kernel            0660   system     system
 /dev/sp_ssr               0660   system     system
 /dev/jpeg0                0660   system     camera


### PR DESCRIPTION
Another device needed to set up a pincode through gatekeeper:

    E spcomlib: [do_ioctl] open() file [/dev/spss_utils] ret [-1] errno [13] [Permission denied]
    E spcomlib: [spcom_wait_for_event] after wait event. ret [-13] status [0x00000000] pid [0x077d04f8]
    E spcomlib: [spcom_wait_for_sp_link_up] PIL not called !
    E KeymasterUtils: SPU is not available
    E KeymasterUtils: IsSbKmAvailable failed
    E GatekeeperHalDevice: delete_user_legacy
    E GatekeeperHalDevice: ret: -45
    E GatekeeperHalDevice: resp->status: 0
    E spcomlib: [do_ioctl] open() file [/dev/spss_utils] ret [-1] errno [13] [Permission denied]
    E spcomlib: [spcom_wait_for_event] after wait event. ret [-13] status [0x00000000] pid [0x077d04f8]
    E spcomlib: [spcom_wait_for_sp_link_up] PIL not called !
    E KeymasterUtils: SPU is not available
    E KeymasterUtils: IsSbKmAvailable failed
    E GatekeeperHalDevice: enroll_legacy
    E GatekeeperHalDevice: ret: -45
    E GatekeeperHalDevice: resp->status: 0

Unfortunately after this fix gatekeeper hangs elsewhere, with non-obvious error-code. To be continued.
