### PR TITLE
[edo] sepolicy/genfs: Import mdss and spmi labels from Kumano

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -34,3 +34,5 @@ genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.q
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/main     u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/pc_port  u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/usb      u:object_r:sysfs_batteryinfo:s0
+
+genfscon sysfs /devices/platform/soc/soc:qcom,mdm0/esoc0                        u:object_r:sysfs_esoc:s0

--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -2,17 +2,15 @@ genfscon sysfs /devices/platform/soc/890000.i2c                                 
 genfscon sysfs /devices/platform/soc/89c000.i2c                                 u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/a88000.i2c                                 u:object_r:sysfs_msm_subsys:s0
 
-genfscon sysfs /devices/platform/soc/2c00000.qcom,kgsl-3d0                      u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/platform/soc/17300000.qcom,lpass                        u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/platform/soc/ae00000.qcom,mdss_mdp                      u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/platform/soc/ae00000.qcom,mdss_rotator                  u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/platform/soc/4080000.qcom,mss                           u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/platform/soc/88c00.qcom,spmi                            u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/platform/soc/aae0000.qcom,venus                         u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/platform/soc/8300000.qcom,turing                        u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,ipa_fws                           u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/soc:qcom,ipa_uc                            u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/17300000.qcom,lpass                        u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/8300000.qcom,turing                        u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/aab0000.qcom,venus                         u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/188101c.qcom,spss                          u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/abb0000.qcom,cvpss                         u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/5c00000.qcom,ssc                           u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/soc:qcom,mdm0                              u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/9800000.qcom,npu                           u:object_r:sysfs_msm_subsys:s0
 
 genfscon sysfs /devices/platform/soc/ac4a000.qcom,cci                           u:object_r:sysfs_camera:s0

--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -18,3 +18,19 @@ genfscon sysfs /devices/platform/soc/9800000.qcom,npu                           
 genfscon sysfs /devices/platform/soc/ac4a000.qcom,cci                           u:object_r:sysfs_camera:s0
 genfscon sysfs /devices/platform/soc/ac4b000.qcom,cci                           u:object_r:sysfs_camera:s0
 
+genfscon sysfs /devices/platform/soc/ae00000.qcom,mdss_mdp/backlight/panel0-backlight                                                        u:object_r:sysfs_leds:s0
+
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-03/c440000.qcom,spmi:qcom,pm8150b@3:qcom,haptics@c000                    u:object_r:sysfs_leds:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-03/c440000.qcom,spmi:qcom,pm8150b@3:qcom,leds@d000                       u:object_r:sysfs_leds:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-05/c440000.qcom,spmi:qcom,pm8150l@5:qcom,leds@d000                       u:object_r:sysfs_leds:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-05/c440000.qcom,spmi:qcom,pm8150l@5:qcom,leds@d300                       u:object_r:sysfs_leds:s0
+
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-00/c440000.qcom,spmi:qcom,pm8150@0:qcom,pm8150_rtc                       u:object_r:sysfs_rtc:s0
+
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qpnp,fg/power_supply/bms             u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qpnp,fg/capacity                     u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/battery  u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/dc       u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/main     u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/pc_port  u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pm8150b@2:qcom,qpnp-smb5/power_supply/usb      u:object_r:sysfs_batteryinfo:s0


### PR DESCRIPTION
SM8250 has the same `pm8150[bl]?` as SM8150, at the same address. Import its labels so that our leds and battery info sysfs attributes are properly labeled. Same for the brightness property on the mdss.
