### PR TITLE
[EDO] [URGENT] platform: Disable SPU for GateKeeper

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -410,6 +410,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.mdm_helper.fail_action=cold_reset
 
+# Gatekeeper
+PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.gatekeeper.disable_spu=true
+
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)


### PR DESCRIPTION
The SPU is loaded by UEFI: this property disables a call to SPCOM
that will try (and fail to) load the SPSS firmware through the spcom library.

Fixes ability to set device PIN (and fingerprint)