### PR TITLE
[edo] audio_platform_info: Override camcorder_mic acdb ID to 544

### DIFF
--- a/rootdir/vendor/etc/audio_platform_info.xml
+++ b/rootdir/vendor/etc/audio_platform_info.xml
@@ -153,6 +153,7 @@
         <device name="SND_DEVICE_OUT_VOICE_SPEAKER_2_PROTECTED" acdb_id="15"/>
         <device name="SND_DEVICE_OUT_VOICE_SPEAKER_2_PROTECTED_VBAT" acdb_id="15"/>
 
+        <device name="SND_DEVICE_IN_CAMCORDER_MIC" acdb_id="544"/>
         <device name="SND_DEVICE_IN_CAPTURE_VI_FEEDBACK" acdb_id="102"/>
         <device name="SND_DEVICE_IN_CAPTURE_VI_FEEDBACK_MONO_1" acdb_id="151"/>
         <device name="SND_DEVICE_IN_CAPTURE_VI_FEEDBACK_MONO_2" acdb_id="152"/>


### PR DESCRIPTION
Stock reports this ACDB ID in video recording, which is different from the default id `4` hardcoded in the Audio HAL. Since we have the same calibration files as stock, we must use their ID.

---

@jerpelea please clean up the branches in this repo! `master` and `main` is unnecessarily duplicated, and `r-mr1` + `master` lag significantly behind `main`.
