### PR TITLE
[EDO] init: Signal FS-READY for calibration to QCA6390 WiFi

### DIFF
--- a/rootdir/vendor/etc/init/init.edo.rc
+++ b/rootdir/vendor/etc/init/init.edo.rc
@@ -16,6 +16,10 @@ on post-fs
     rm /persist/bluetooth/.bt_nv.bin
     rmdir /persist/bluetooth
 
+on post-fs-data
+    # Enable WLAN cold boot calibration
+    write /sys/devices/platform/soc/b0000000.qcom,cnss-qca6390/fs_ready 1
+
 on init
     # Boot time fs tune
     write /sys/block/sda/queue/iostats 0


### PR DESCRIPTION
Signal fs-ready to qca6390 to start wlan calibration.