### PR TITLE
[EDO] audio_policy: Add wired headset mic source for voip_tx

### DIFF
--- a/rootdir/vendor/etc/caf_common_primary_audio_policy_configuration.xml
+++ b/rootdir/vendor/etc/caf_common_primary_audio_policy_configuration.xml
@@ -289,7 +289,7 @@
         <route type="mix" sink="primary input"
                sources="Built-In Mic,Built-In Back Mic,Wired Headset Mic,BT SCO Headset Mic,FM Tuner,Telephony Rx"/>
         <route type="mix" sink="voip_tx"
-               sources="Built-In Mic,Built-In Back Mic,BT SCO Headset Mic"/>
+               sources="Built-In Mic,Built-In Back Mic,Wired Headset Mic,BT SCO Headset Mic"/>
         <route type="mix" sink="record_24"
                sources="Built-In Mic,Built-In Back Mic,Wired Headset Mic"/>
         <route type="mix" sink="mmap_no_irq_in"


### PR DESCRIPTION
Being able to use a wired headset during VoIP is definitely a good idea.