### PR TITLE
[EDO] platform: audio: Enable concurrent compressed input

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -352,6 +352,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Audio - QCOM HAL
 PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.audio.feature.concurrent_capture.enable=true \
     vendor.audio.feature.compress_in.enable=true \
     vendor.audio.feature.display_port.enable=true \
     vendor.audio.feature.hdmi_edid.enable=true \


### PR DESCRIPTION
Enable concurrent_capture in order to be able to use more than
one input stream at the same time.

This fixes issues with Telegram/Whatsapp/whatever-else while
Voice Match is enabled.