### PR TITLE
PlatformConfig.mk: Switch to generic cpu variant

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -16,13 +16,17 @@ TARGET_ARCH := arm64
 TARGET_ARCH_VARIANT := armv8-2a
 TARGET_CPU_ABI := arm64-v8a
 TARGET_CPU_ABI2 :=
-TARGET_CPU_VARIANT := cortex-a75
+TARGET_CPU_VARIANT := generic
+# Switch to Cortex-A77 when it becomes available!
+TARGET_CPU_VARIANT_RUNTIME := generic
 
 TARGET_2ND_ARCH := arm
 TARGET_2ND_ARCH_VARIANT := armv8-2a
 TARGET_2ND_CPU_ABI := armeabi-v7a
 TARGET_2ND_CPU_ABI2 := armeabi
-TARGET_2ND_CPU_VARIANT := cortex-a75
+TARGET_2ND_CPU_VARIANT := generic
+# Switch to Cortex-A77 when it becomes available!
+TARGET_2ND_CPU_VARIANT_RUNTIME := generic
 
 BOARD_KERNEL_BASE        := 0x00000000
 BOARD_KERNEL_PAGESIZE    := 4096


### PR DESCRIPTION
We previously optimized all the code for CA75, which is..
suboptimal to say the least, since our bigcores are CA77
and even worse - the LITTLE cluster is still based on the
old A55! We were shooting ourselves in our feet performance-wise!

Google also decided to go like this:

TARGET_CPU_VARIANT := generic
TARGET_CPU_VARIANT_RUNTIME := $(big_core_march)

Since there is no CA77 optimization in libbionic yet, set
it to generic until it's fixed on the AOSP end.

Follow the scheme, saving us GIGATONS of disk space (by
reusing generic binaries for all devices).