### PR TITLE
[edo] [R/master] sepolicy/genfs_contexts: Label missing b0000000.qcom,cnss-qca6390 subsys

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -12,6 +12,7 @@ genfscon sysfs /devices/platform/soc/abb0000.qcom,cvpss                         
 genfscon sysfs /devices/platform/soc/5c00000.qcom,ssc                           u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,mdm0                              u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/9800000.qcom,npu                           u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/b0000000.qcom,cnss-qca6390                 u:object_r:sysfs_msm_subsys:s0
 
 genfscon sysfs /devices/platform/soc/ac4a000.qcom,cci                           u:object_r:sysfs_camera:s0
 genfscon sysfs /devices/platform/soc/ac4b000.qcom,cci                           u:object_r:sysfs_camera:s0


### PR DESCRIPTION
This subsystem is unlabeled:

    I mdm_helper: avc: denied { read } for name="name" dev="sysfs" scontext=u:r:mdm_helper:s0 tcontext=u:object_r:sysfs:s0 tclass=file
    I mdm_helper: avc: denied { open } for path="/sys/devices/platform/soc/b0000000.qcom,cnss-qca6390/subsys9/name" dev="sysfs" scontext=u:r:mdm_helper:s0 tcontext=u:object_r:sysfs:s0 tclass=file
