### PR TITLE
[2/2] [R] Include missing kona_stk3x3x_0 sensor file; move Edo-specific (platform) sensor overlays in from common

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -320,6 +320,7 @@ PRODUCT_PACKAGES += \
     kona_qrd_tmd2725_0.json \
     kona_shtw2_0.json \
     kona_somc_default_sensors.json \
+    kona_stk3x3x_0.json \
     kona_svr_bma4_0.json \
     kona_svr_bmg160_0.json \
     kona_svr_icm4x6xx_0.json \

--- a/platform.mk
+++ b/platform.mk
@@ -300,7 +300,6 @@ PRODUCT_PACKAGES += \
 # Platform SSC Sensors
 PRODUCT_PACKAGES += \
     kona_ak991x_0.json \
-    kona_ak991x_0_somc_platform.json \
     kona_bmp380_0.json \
     kona_bu52053nvx_0.json \
     kona_default_sensors.json \
@@ -339,6 +338,11 @@ PRODUCT_PACKAGES += \
     sns_wrist_pedo.json \
     stk3x3x_0.json \
     wigig_sensing_0.json
+
+# Platform-specific sensor overlays
+PRODUCT_COPY_FILES += \
+    $(SONY_ROOT)/vendor/etc/sensors/config/kona_ak991x_0_somc_platform.json:$(TARGET_COPY_OUT_VENDOR)/etc/sensors/config/kona_ak991x_0_somc_platform.json \
+    $(SONY_ROOT)/vendor/etc/sensors/config/sns_device_orient_somc_platform.json:$(TARGET_COPY_OUT_VENDOR)/etc/sensors/config/sns_device_orient_somc_platform.json
 
 # CAMERA
 TARGET_USES_64BIT_CAMERA := true

--- a/rootdir/vendor/etc/sensors/config/kona_ak991x_0_somc_platform.json
+++ b/rootdir/vendor/etc/sensors/config/kona_ak991x_0_somc_platform.json
@@ -1,0 +1,61 @@
+{
+  "config":
+  {
+    "hw_platform": ["MTP", "Surf", "QRD"],
+    "soc_id": ["356"]
+  },
+  "ak0991x_0_platform":{
+    "owner": "sns_ak0991x",
+    ".config":{
+      "owner": "sns_ak0991x",
+      "bus_type":{ "type": "int", "ver": "1",
+        "data": "0"
+      },
+      "irq_pull_type":{ "type": "int", "ver": "1",
+        "data": "0"
+      },
+      "i3c_address":{ "type": "int", "ver": "1",
+        "data": "0"
+      },
+      "max_bus_speed_khz":{ "type": "int", "ver": "1",
+        "data": "400"
+      }
+    },
+    ".mag":{
+      "owner": "sns_ak0991x",
+      ".fac_cal":{
+        "owner": "sns_ak0991x",
+        ".corr_mat":{
+          "owner": "sns_ak0991x",
+          "0_0":{ "type": "flt", "ver": "1",
+            "data": "1.0"
+          },
+          "0_1":{ "type": "flt", "ver": "1",
+            "data": "0.0"
+          },
+          "0_2":{ "type": "flt", "ver": "1",
+            "data": "0.0"
+          },
+          "1_0":{ "type": "flt", "ver": "1",
+            "data": "0.0"
+          },
+          "1_1":{ "type": "flt", "ver": "1",
+            "data": "1.0"
+          },
+          "1_2":{ "type": "flt", "ver": "1",
+            "data": "0.0"
+          },
+          "2_0":{ "type": "flt", "ver": "1",
+            "data": "0.0"
+          },
+          "2_1":{ "type": "flt", "ver": "1",
+            "data": "0.0"
+          },
+          "2_2":{ "type": "flt", "ver": "1",
+            "data": "1.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/rootdir/vendor/etc/sensors/config/sns_device_orient_somc_platform.json
+++ b/rootdir/vendor/etc/sensors/config/sns_device_orient_somc_platform.json
@@ -1,0 +1,22 @@
+{
+  "config":
+  {
+    "hw_platform": ["MTP", "Dragon", "Surf", "QRD", "HDK", "IDP"],
+    "soc_id": ["394", "356"]
+  },
+  "sns_device_orient_platform": {
+    "owner": "sns_device_orient",
+    ".config":{
+      "owner": "sns_device_orient",
+      "param3": {
+         "type": "flt", "ver": "1", "data": "55.0"
+      },
+      "param5": {
+         "type": "flt", "ver": "1", "data": "1.5"
+      },
+      "param6": {
+         "type": "flt", "ver": "1", "data": "15.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Complements https://github.com/sonyxperiadev/device-sony-common/pull/852, depends on #42 

---

Without this file a regen of the persistent sensor configuration results in the proximity and ambient light sensor (both provided by the Sensortek 3x3x) to disappear.  The file exists in common with a matching prebuilt build rule, but was simply missed here.

---

These overlays are platform-specific (as indicated by `_somc_platform`) and should not reside in the common repository (unlike SoC specific files, which may or may not be generic depending on future boards). Note that `sns_device_orient_somc_platform` was previously missing entirely.