### PR TITLE
[R/S] bdroid_buildcfg: Use space between the device number and revision

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -33,11 +33,11 @@ static inline const char* getBTDefaultName()
     property_get("ro.boot.hardware", device, "");
 
     if (!strcmp("pdx203", device)) {
-        return "Xperia 1II";
+        return "Xperia 1 II";
     }
 
     if (!strcmp("pdx206", device)) {
-        return "Xperia 5II";
+        return "Xperia 5 II";
     }
 
     return "Xperia";


### PR DESCRIPTION
Just like the other platforms and stock, and simply because it looks
much better that way, add a space between `1 II` and `5 II`.
