### PR TITLE
[R/S] sepolicy: Label mdm partitions as `efs_boot_device`

### DIFF
--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -110,4 +110,9 @@
 /dev/block/platform/soc/1d84000\.ufshc/by-name/vbmeta(_system)?_[ab]   u:object_r:vbmeta_block_device:s0
 /dev/block/bootdevice/by-name/vbmeta(_system)?_[ab]                    u:object_r:vbmeta_block_device:s0
 
+/dev/block/platform/soc/1d84000\.ufshc/by-name/mdm1m9kefs[1-3]         u:object_r:efs_boot_device:s0
+/dev/block/bootdevice/by-name/mdm1m9kefs[1-3]                          u:object_r:efs_boot_device:s0
+/dev/block/platform/soc/1d84000\.ufshc/by-name/mdmddr                  u:object_r:efs_boot_device:s0
+/dev/block/bootdevice/by-name/mdmddr                                   u:object_r:efs_boot_device:s0
+
 /dev/block/zram0                                               u:object_r:swap_block_device:s0


### PR DESCRIPTION
These partitions are read by `mdm_helper` and receive a specific `efs_boot_device` label so that _just_ this `mdm_helper` domain is granted read-access.  Addresses the following denials:

    denied { search } for comm="ks" name="block" scontext=u:r:mdm_helper:s0 tcontext=u:object_r:block_device:s0 tclass=dir
    denied { getattr } for comm="ks" path="/dev/block/sda42" scontext=u:r:mdm_helper:s0 tcontext=u:object_r:block_device:s0 tclass=blk_file
    denied { read } for comm="ks" name="sda42" scontext=u:r:mdm_helper:s0 tcontext=u:object_r:block_device:s0 tclass=blk_file
    denied { open } for comm="ks" path="/dev/block/sda42" scontext=u:r:mdm_helper:s0 tcontext=u:object_r:block_device:s0 tclass=blk_file
    denied { search } for comm="ks" name="block" scontext=u:r:mdm_helper:s0 tcontext=u:object_r:block_device:s0 tclass=dir
    denied { getattr } for comm="ks" path="/dev/block/sda8" scontext=u:r:mdm_helper:s0 tcontext=u:object_r:block_device:s0 tclass=blk_file
    denied { read } for comm="ks" name="sda8" scontext=u:r:mdm_helper:s0 tcontext=u:object_r:block_device:s0 tclass=blk_file
    denied { open } for comm="ks" path="/dev/block/sda8" scontext=u:r:mdm_helper:s0 tcontext=u:object_r:block_device:s0 tclass=blk_file

Depends on the addition of the `efs_boot_device` `dev_type` to the sepolicy repository: sonyxperiadev/device-sony-sepolicy#605