### PR TITLE
[u-mr1] platform: Add BOARD_WLAN_CHIP flag

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -47,6 +47,7 @@ BOARD_HAS_QCOM_WLAN := true
 BOARD_HOSTAPD_DRIVER := NL80211
 BOARD_HOSTAPD_PRIVATE_LIB := lib_driver_cmd_qcwcn
 BOARD_WLAN_DEVICE := qcwcn
+BOARD_WLAN_CHIP := wcn6740
 BOARD_WPA_SUPPLICANT_DRIVER := NL80211
 BOARD_WPA_SUPPLICANT_PRIVATE_LIB := lib_driver_cmd_qcwcn
 HOSTAPD_VERSION := VER_0_8_X
@@ -58,6 +59,9 @@ TARGET_USES_ICNSS_QMI := true
 WIFI_DRIVER_STATE_CTRL_PARAM := "/dev/wlan"
 WIFI_DRIVER_STATE_OFF := "OFF"
 WIFI_DRIVER_STATE_ON := "ON"
+
+# Add BOARD_WLAN_CHIP to soong_config
+$(call soong_config_set,qcom_wifi,board_wlan_chip,wcn6740)
 
 # BT definitions for Qualcomm solution
 BOARD_HAVE_BLUETOOTH := true


### PR DESCRIPTION
Add BOARD_WLAN_CHIP flag. AOSP provides two versions of HAL.
A very old legacy version and a fresh one, which they protected
with the BOARD_WLAN_CHIP flag which corresponds to the value wcn6740.
Also add a soong config variable for BOARD_WLAN_CHIP to switch the
implementation.