### PR TITLE
[u-mr1] platform: Update shipping API level

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -110,7 +110,14 @@ PRODUCT_BUILD_BOOT_IMAGE := true
 
 # A/B support
 AB_OTA_UPDATER := true
-PRODUCT_SHIPPING_API_LEVEL := 27
+
+# Platform has been launched on Android 10 (API level 29)
+# Workaround for the bug: https://github.com/sonyxperiadev/bug_tracker/issues/851.
+# Caused by: https://android.googlesource.com/platform/art/+/760e495e79c03ce9c748a93ff42e6e3dd00bfc05.
+# Google addressed it in the commit: https://android.googlesource.com/platform/art/+/84c0eddb305a3248046edd3f2f8bba03aab3efec,
+# but it’s likely that this will never be backported to Android 14, and the simplest
+# way to workaround this is to bump the Shipping API level to 30.
+PRODUCT_SHIPPING_API_LEVEL := 30
 
 # A/B OTA dexopt package
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Platform has been launched on Android 10, but Shipping API
level was increased to Android 11. Reason:
Workaround for the bug: https://github.com/sonyxperiadev/bug_tracker/issues/851.
Caused by: https://android.googlesource.com/platform/art/+/760e495e79c03ce9c748a93ff42e6e3dd00bfc05.
Google addressed it in the commit: https://android.googlesource.com/platform/art/+/84c0eddb305a3248046edd3f2f8bba03aab3efec,
but it’s likely that this will never be backported to Android 14, and the simplest
way to workaround this is to bump the Shipping API level to 30.