### PR TITLE
[u-mr1] platform: Switch to tad_legacy

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -230,7 +230,7 @@ DEVICE_MANIFEST_FILE += $(PLATFORM_COMMON_PATH)/vintf/android.hardware.authsecre
 
 # Platform specific init
 PRODUCT_PACKAGES += \
-    tad.rc \
+    tad_legacy.rc \
     init.edo \
     init.edo.pwr \
     ueventd


### PR DESCRIPTION
ODM for kernel 4.19 platforms supplies legacy tad_static.